### PR TITLE
Add Docker Compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.pytest_cache/
+.env
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && pip install --upgrade pip \
+    && pip install -r requirements.txt \
+    && pip install uv \
+    && apt-get purge -y build-essential \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # AgentsSDK-explore
 Explore the agents SDK capabilities
+
+## Running with Docker Compose
+
+1. Build and start the services:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   This command starts two containers:
+
+   - `server`: exposes the Streamable HTTP MCP server on port `8000`.
+   - `app`: runs `main.py`, which connects to the server and demonstrates the sample interactions.
+
+2. To stop the containers, press `Ctrl+C` and run:
+
+   ```bash
+   docker compose down
+   ```
+
+### Environment variables
+
+The application can be configured with the following variables:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `MCP_SERVER_URL` | URL of the MCP server used by `main.py`. | `http://localhost:8000/mcp` |
+| `START_LOCAL_SERVER` | Set to `0`/`false` to skip starting a local server subprocess. | `1` |
+| `LOCAL_SERVER_COMMAND` | Custom command to start the local server (overrides the default `uv run server.py`). | *(unset)* |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+
+services:
+  server:
+    build: .
+    command: ["python", "server.py"]
+    ports:
+      - "8000:8000"
+
+  app:
+    build: .
+    command: ["python", "main.py"]
+    environment:
+      MCP_SERVER_URL: http://server:8000/mcp
+      START_LOCAL_SERVER: "0"
+    depends_on:
+      - server


### PR DESCRIPTION
## Summary
- add a Dockerfile and docker-compose definition to containerize the project
- make the example script configurable so it can connect to an external MCP server
- document the container workflow and add a Docker ignore file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dca0dae278832caef09ff7f329799d